### PR TITLE
qstring update, BoxID to string

### DIFF
--- a/api_box.go
+++ b/api_box.go
@@ -3,7 +3,7 @@ package cex
 import (
 	"encoding/json"
 
-	"github.com/Southclaws/qstring"
+	"github.com/dyninc/qstring"
 )
 
 // Box represents an individual product
@@ -51,7 +51,7 @@ type BoxesParams struct {
 	// One of these must be present
 	SuperCatIDs []int `qstring:"superCatIds"` // super category ID
 	CategoryIDs []int `qstring:"categoryIds"` // category ID
-	BoxID       int   `qstring:"q"`           // box ID
+	BoxID       string   `qstring:"q"`           // box ID
 
 	// These are all optional
 	FirstRecord int    `qstring:"firstRecord,omitempty"` // default: 50, basically a database OFFSET


### PR DESCRIPTION
I cannot find the Southclaws qstring github anymore so I switched it to dyninc's qstring.
I also switched BoxID to a string instead of an int, forgot that BoxID's can be strings too.

Tested:
![image](https://user-images.githubusercontent.com/33849459/86805564-e12dcf00-c06f-11ea-9566-78521cca5be5.png)
